### PR TITLE
Mellanox | Add condition for 'mlxplat' mount

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -685,7 +685,7 @@ start() {
         -v /usr/bin/asic_detect:/usr/bin/asic_detect:rw \
         -e SX_API_SOCKET_FILE=/var/run/sx_sdk/sx_api.sock \
 {%- elif docker_container_name == "pmon" %}
-        -v /sys/devices/platform/mlxplat:/sys/devices/platform/mlxplat:rw \
+        $(if [ -e /sys/devices/platform/mlxplat ]; then echo "-v /sys/devices/platform/mlxplat:/sys/devices/platform/mlxplat:rw"; fi) \
         -v /sys/module/sx_core:/sys/module/sx_core:rw \
         -v /var/run/hw-management:/var/run/hw-management:rw \
         -v /etc/hw-management-sensors:/etc/hw-management-sensors:ro \


### PR DESCRIPTION
#### Why I did it
In some of Mellanox SimX platforms, the path /sys/devices/platform/mlxplat doesn't exist (HW-Mgmt emulation limitation).

#### How I did it
By adding a condition to docker_image_ctl.j2, for pmon.sh, in order to mount /sys/devices/platform/mlxplat only if this path exists

#### How to verify it
1. In Mellanox platforms that include this path - verify it is accessible from pmon
2. In new Mellanox SimX platforms - verify pmon container is up as expected (mounting an unexisting path leads to pmon container failure).