### PR TITLE
[docker-wait-any] check warm-restart in correct namespace

### DIFF
--- a/src/sonic-ctrmgrd-rs/Cargo.lock
+++ b/src/sonic-ctrmgrd-rs/Cargo.lock
@@ -421,6 +421,7 @@ dependencies = [
  "mockall",
  "serial_test",
  "sonic-rs-common",
+ "swss-common",
  "syslog-tracing",
  "thiserror",
  "tokio",

--- a/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/Cargo.toml
+++ b/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/Cargo.toml
@@ -23,6 +23,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 syslog-tracing = { workspace = true }
 sonic-rs-common = { path = "../../../sonic-rs-common" }
+swss-common = { path = "../../../sonic-swss-common/crates/swss-common" }
+
 
 [dev-dependencies]
 serial_test = "1.0.0"

--- a/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/lib.rs
+++ b/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/lib.rs
@@ -21,6 +21,8 @@ pub enum Error {
     DeviceInfo(#[from] sonic_rs_common::device_info::DeviceInfoError),
     #[error("Syslog initialization error: {0}")]
     Syslog(String),
+    #[error("SWSS common error")]
+    SwssError(#[from] swss_common::Exception),
 }
 
 pub trait DockerApi: Send + Sync {
@@ -86,7 +88,8 @@ pub async fn wait_for_container(
         info!("No longer waiting on container '{}'", container_name);
 
         if dependent_services.contains(&container_name) {
-            let warm_restart = device_info::is_warm_restart_enabled(&container_name)?;
+            let (service_name, namespace) = parse_container_name(&container_name);
+            let warm_restart = device_info::is_warm_restart_enabled_in_namespace(service_name, &namespace)?;
             let fast_reboot = device_info::is_fast_reboot_enabled()?;
 
             if warm_restart || fast_reboot {
@@ -96,6 +99,18 @@ pub async fn wait_for_container(
 
         exit_event.store(true, Ordering::Release);
         return Ok(());
+    }
+}
+
+fn parse_container_name(container_name: &str) -> (&str, String) {
+    match container_name.find(|c: char| c.is_digit(10)) {
+        Some(index) => {
+            let (service_name, namespace) = container_name.split_at(index);
+            (service_name, format!("asic{}", namespace))
+        }
+        None => {
+            (container_name, "".to_string())
+        }
     }
 }
 

--- a/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/main.rs
+++ b/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/main.rs
@@ -33,6 +33,10 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    const DEFAULT_DATABASE_GLOBAL_CONFIG_PATH: &'static str = "/var/run/redis/sonic-db/database_global.json";
+    if std::path::Path::new(DEFAULT_DATABASE_GLOBAL_CONFIG_PATH).exists() {
+        swss_common::sonic_db_config_initialize_global(DEFAULT_DATABASE_GLOBAL_CONFIG_PATH, true)?;
+    }
     let identity = CString::new("docker-wait-any-rs")
         .map_err(|e| Error::Syslog(format!("invalid identity string: {}", e)))?;
     let syslog = syslog_tracing::Syslog::new(

--- a/src/sonic-rs-common/src/device_info.rs
+++ b/src/sonic-rs-common/src/device_info.rs
@@ -24,6 +24,11 @@ impl StateDBConnector {
         let db = DbConnector::new_named("STATE_DB", true, 0)?;
         Ok(StateDBConnector { db })
     }
+
+    pub fn new_with_namespace(namespace: &str) -> std::result::Result<Self, swss_common::Exception> {
+        let db = DbConnector::new_keyed("STATE_DB", false, 0, "", namespace)?;
+        Ok(StateDBConnector { db })
+    }
 }
 
 impl StateDBTrait for StateDBConnector {
@@ -65,6 +70,12 @@ pub fn is_fast_reboot_enabled_with_db<T: StateDBTrait>(state_db: &T) -> Result<b
 // Public API functions using production database
 pub fn is_warm_restart_enabled(container_name: &str) -> Result<bool> {
     let state_db = StateDBConnector::new()
+        .map_err(|e| DeviceInfoError::SwSS(e))?;
+    is_warm_restart_enabled_with_db(container_name, &state_db)
+}
+
+pub fn is_warm_restart_enabled_in_namespace(container_name: &str, namespace: &str) -> Result<bool> {
+    let state_db = StateDBConnector::new_with_namespace(namespace)
         .map_err(|e| DeviceInfoError::SwSS(e))?;
     is_warm_restart_enabled_with_db(container_name, &state_db)
 }

--- a/src/sonic-rs-common/tests/device_info_test.rs
+++ b/src/sonic-rs-common/tests/device_info_test.rs
@@ -163,6 +163,21 @@ mod test_device_info {
 
     // Integration test for public API (will use real database connection, may fail in test env)
     #[test]
+    fn test_is_warm_restart_enabled_in_namespace_public_api() {
+        let result = is_warm_restart_enabled_in_namespace("swss", "asic0");
+        // Test passes regardless of result since database may not be available in test environment
+        match result {
+            Ok(_) => {
+                // Function succeeded - database was available
+            }
+            Err(_) => {
+                // Function failed - expected in test environment without database
+            }
+        }
+    }
+    
+    // Integration test for public API (will use real database connection, may fail in test env)
+    #[test]
     fn test_is_fast_reboot_enabled_public_api() {
         let result = is_fast_reboot_enabled();
         // Test passes regardless of result since database may not be available in test environment


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

